### PR TITLE
Fix datetime creation error

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -72,7 +72,7 @@ class Util
         $microseconds = sprintf('%06d', ($time - floor($time)) * 1000000);
         $millseconds = round($microseconds, -3)/1000;
         $millsecondsStr = str_pad($millseconds, 3, '0', STR_PAD_LEFT);
-        $date = (new \DateTime(null, new \DateTimeZone("UTC")))->format('c');
+        $date = (new \DateTime('now', new \DateTimeZone("UTC")))->format('c');
 
         $position = strrpos($date, '+');
         $date = substr($date,0,$position).'.'.$millsecondsStr.substr($date,$position);


### PR DESCRIPTION
After switching to php8 there is an error on tincan activity pages: 
`Deprecated function: DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in TinCan\Util::getTimestamp() (line 75 of vendor/opigno/tincan/src/Util.php). `