### PR TITLE
Remove usage of deprecated "$errcontext" parameter

### DIFF
--- a/src/RemoteLRS.php
+++ b/src/RemoteLRS.php
@@ -137,7 +137,7 @@ class RemoteLRS implements LRSInterface
         // normal handling
         //
         set_error_handler(
-            function ($errno, $errstr, $errfile, $errline, array $errcontext) {
+            function ($errno, $errstr, $errfile, $errline) {
                 // "!== false" is intentional. strpos() can return 0, which is falsey, but returning
                 // 0 matches our "true" condition. Using strict equality to avoid that confusion.
                 if ($errno == E_NOTICE && strpos($errstr, 'Array to string conversion') !== false) {


### PR DESCRIPTION
The `$errcontext` parameter for the callback used with `set_error_handler` was deprecated in PHP 7.2 and removed in PHP 8. Usage of it causes the following error

```
ArgumentCountError: Too few arguments to function TinCan\RemoteLRS::TinCan\{closure}(), 4 passed and exactly 5 expected
```

https://www.php.net/manual/en/function.set-error-handler.php#refsect1-function.set-error-handler-parameters